### PR TITLE
Ny route for å vise flere utbetalinger på Min side

### DIFF
--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
@@ -89,11 +89,16 @@ data class SisteOgKommendeUtbetalinger(
 ) {
     companion object {
 
-        fun fromSokosResponse(utbetalinger: List<UtbetalingEkstern>): SisteOgKommendeUtbetalinger {
+        fun fromSokosResponse(
+            utbetalinger: List<UtbetalingEkstern>,
+            fom: LocalDate,
+            tom: LocalDate
+        ): SisteOgKommendeUtbetalinger {
             val now: LocalDate = LocalDate.now()
             val antall = 2
-            val siste = utbetalinger.listeMedSisteUtbetalinger(now, antall)
-            val nesteUtbetaling = utbetalinger.listeMedKommendeUtbetalinger(now)
+            val iPeriode = utbetalinger.filter { it.isInPeriod(fom, tom) }
+            val siste = iPeriode.listeMedSisteUtbetalinger(now, antall)
+            val nesteUtbetaling = iPeriode.listeMedKommendeUtbetalinger(now)
 
             return SisteOgKommendeUtbetalinger(
                 sisteUtbetalinger = siste.flatMap { utbetalingEkstern ->

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
@@ -91,30 +91,33 @@ data class SisteOgKommendeUtbetalinger(
 
         fun fromSokosResponse(utbetalinger: List<UtbetalingEkstern>): SisteOgKommendeUtbetalinger {
             val now: LocalDate = LocalDate.now()
-            val siste = utbetalinger.listeMedSisteUtbetalinger(now,2)
-            val nesteUtbetaling = utbetalinger.listeMedKommendeUtbetalinger(now,2)
+            val antall = 2
+            val siste = utbetalinger.listeMedSisteUtbetalinger(now, antall)
+            val nesteUtbetaling = utbetalinger.listeMedKommendeUtbetalinger(now)
 
             return SisteOgKommendeUtbetalinger(
-                sisteUtbetalinger = siste.map { utbetalingEkstern ->
-                    val ytelse = utbetalingEkstern.ytelseListe.first()
-                    UtbetalingOppsummering(
-                        id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
-                        utbetaling = ytelse.ytelseNettobeloep,
-                        kontonummer = utbetalingEkstern.maskertKontonummer(),
-                        ytelse = ytelse.ytelsestype ?: "Diverse",
-                        dato = utbetalingEkstern.ytelsesdato()!!
-                    )
-                },
-                kommendeUtbetalinger = nesteUtbetaling.map { utbetalingEkstern ->
-                    val ytelse = utbetalingEkstern.ytelseListe.first()
-                    UtbetalingOppsummering(
-                        id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
-                        utbetaling = ytelse.ytelseNettobeloep,
-                        kontonummer = utbetalingEkstern.maskertKontonummer(),
-                        ytelse = ytelse.ytelsestype ?: "Diverse",
-                        dato = utbetalingEkstern.ytelsesdato()!!
-                    )
-                }
+                sisteUtbetalinger = siste.flatMap { utbetalingEkstern ->
+                    utbetalingEkstern.ytelseListe.map { ytelse ->
+                        UtbetalingOppsummering(
+                            id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
+                            utbetaling = ytelse.ytelseNettobeloep,
+                            kontonummer = utbetalingEkstern.maskertKontonummer(),
+                            ytelse = ytelse.ytelsestype ?: "Diverse",
+                            dato = utbetalingEkstern.ytelsesdato()!!
+                        )
+                    }
+                }.take(antall),
+                kommendeUtbetalinger = nesteUtbetaling.flatMap { utbetalingEkstern ->
+                    utbetalingEkstern.ytelseListe.map { ytelse ->
+                        UtbetalingOppsummering(
+                            id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
+                            utbetaling = ytelse.ytelseNettobeloep,
+                            kontonummer = utbetalingEkstern.maskertKontonummer(),
+                            ytelse = ytelse.ytelsestype ?: "Diverse",
+                            dato = utbetalingEkstern.ytelsesdato()!!
+                        )
+                    }
+                }.take(antall)
             )
         }
     }

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
@@ -84,10 +84,8 @@ data class SisteOgNesteUtbetaling(
 
 @Serializable
 data class SisteOgKommendeUtbetalinger(
-    val hasUtbetaling: Boolean,
-    val hasKommende: Boolean,
-    val sisteUtbetaling: List<UtbetalingOppsummering>,
-    val kommende: List<UtbetalingOppsummering>
+    val sisteUtbetalinger: List<UtbetalingOppsummering>,
+    val kommendeUtbetalinger: List<UtbetalingOppsummering>
 ) {
     companion object {
 
@@ -97,9 +95,7 @@ data class SisteOgKommendeUtbetalinger(
             val nesteUtbetaling = utbetalinger.listeMedKommendeUtbetalinger(now,2)
 
             return SisteOgKommendeUtbetalinger(
-                hasUtbetaling = siste.size > 0,
-                hasKommende = nesteUtbetaling.size > 0,
-                sisteUtbetaling = siste.map { utbetalingEkstern ->
+                sisteUtbetalinger = siste.map { utbetalingEkstern ->
                     val ytelse = utbetalingEkstern.ytelseListe.first()
                     UtbetalingOppsummering(
                         id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
@@ -109,7 +105,7 @@ data class SisteOgKommendeUtbetalinger(
                         dato = utbetalingEkstern.ytelsesdato()!!
                     )
                 },
-                kommende = nesteUtbetaling.map { utbetalingEkstern ->
+                kommendeUtbetalinger = nesteUtbetaling.map { utbetalingEkstern ->
                     val ytelse = utbetalingEkstern.ytelseListe.first()
                     UtbetalingOppsummering(
                         id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
@@ -97,11 +97,11 @@ data class SisteOgKommendeUtbetalinger(
             val now: LocalDate = LocalDate.now()
             val antall = 2
             val iPeriode = utbetalinger.filter { it.isInPeriod(fom, tom) }
-            val siste = iPeriode.listeMedSisteUtbetalinger(now, antall)
-            val nesteUtbetaling = iPeriode.listeMedKommendeUtbetalinger(now)
+            val sisteUtbetalinger = iPeriode.listeMedSisteUtbetalinger(now, antall)
+            val nesteUtbetalinger = iPeriode.listeMedKommendeUtbetalinger(now)
 
             return SisteOgKommendeUtbetalinger(
-                sisteUtbetalinger = siste.flatMap { utbetalingEkstern ->
+                sisteUtbetalinger = sisteUtbetalinger.flatMap { utbetalingEkstern ->
                     utbetalingEkstern.ytelseListe.map { ytelse ->
                         UtbetalingOppsummering(
                             id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
@@ -112,7 +112,7 @@ data class SisteOgKommendeUtbetalinger(
                         )
                     }
                 }.take(antall),
-                kommendeUtbetalinger = nesteUtbetaling.flatMap { utbetalingEkstern ->
+                kommendeUtbetalinger = nesteUtbetalinger.flatMap { utbetalingEkstern ->
                     utbetalingEkstern.ytelseListe.map { ytelse ->
                         UtbetalingOppsummering(
                             id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/Utbetalinger.kt
@@ -3,6 +3,8 @@ package no.nav.tms.utbetalingsoversikt.api.utbetaling
 import kotlinx.serialization.Serializable
 import no.nav.tms.utbetalingsoversikt.api.config.LocalDateSerializer
 import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.UtbetalingEkstern
+import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.UtbetalingEkstern.Companion.listeMedKommendeUtbetalinger
+import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.UtbetalingEkstern.Companion.listeMedSisteUtbetalinger
 import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.UtbetalingEkstern.Companion.nesteUtbetaling
 import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.UtbetalingEkstern.Companion.sisteUtbetaling
 import no.nav.tms.utbetalingsoversikt.api.ytelse.domain.external.YtelseEkstern
@@ -65,6 +67,49 @@ data class SisteOgNesteUtbetaling(
                     )
                 },
                 kommende = nesteUtbetaling?.let { utbetalingEkstern ->
+                    val ytelse = utbetalingEkstern.ytelseListe.first()
+                    UtbetalingOppsummering(
+                        id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
+                        utbetaling = ytelse.ytelseNettobeloep,
+                        kontonummer = utbetalingEkstern.maskertKontonummer(),
+                        ytelse = ytelse.ytelsestype ?: "Diverse",
+                        dato = utbetalingEkstern.ytelsesdato()!!
+                    )
+                }
+            )
+        }
+    }
+}
+
+
+@Serializable
+data class SisteOgKommendeUtbetalinger(
+    val hasUtbetaling: Boolean,
+    val hasKommende: Boolean,
+    val sisteUtbetaling: List<UtbetalingOppsummering>,
+    val kommende: List<UtbetalingOppsummering>
+) {
+    companion object {
+
+        fun fromSokosResponse(utbetalinger: List<UtbetalingEkstern>): SisteOgKommendeUtbetalinger {
+            val now: LocalDate = LocalDate.now()
+            val siste = utbetalinger.listeMedSisteUtbetalinger(now,2)
+            val nesteUtbetaling = utbetalinger.listeMedKommendeUtbetalinger(now,2)
+
+            return SisteOgKommendeUtbetalinger(
+                hasUtbetaling = siste.size > 0,
+                hasKommende = nesteUtbetaling.size > 0,
+                sisteUtbetaling = siste.map { utbetalingEkstern ->
+                    val ytelse = utbetalingEkstern.ytelseListe.first()
+                    UtbetalingOppsummering(
+                        id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),
+                        utbetaling = ytelse.ytelseNettobeloep,
+                        kontonummer = utbetalingEkstern.maskertKontonummer(),
+                        ytelse = ytelse.ytelsestype ?: "Diverse",
+                        dato = utbetalingEkstern.ytelsesdato()!!
+                    )
+                },
+                kommende = nesteUtbetaling.map { utbetalingEkstern ->
                     val ytelse = utbetalingEkstern.ytelseListe.first()
                     UtbetalingOppsummering(
                         id = YtelseIdUtil.calculateId(utbetalingEkstern.posteringsdato, ytelse),

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -96,16 +96,6 @@ fun Route.utbetalingRoutesTokenX(sokosUtbetalingConsumer: SokosUtbetalingConsume
             call.respond(HttpStatusCode.OK, SisteOgNesteUtbetaling.fromSokosResponse(sisteUtbetaling))
         }
 
-        get("/minside-widget") {
-            val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
-                user = call.user,
-                fom = LocalDate.now().minusDays(21),
-                tom = LocalDate.now().plusDays(7)
-            )
-
-            call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
-        }
-
         get("/{ytelseId}") {
 
             val ytelseId = call.parameters["ytelseId"] ?: throw IllegalYtelseIdException("Ytelseid kan ikke være null")

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -40,13 +40,20 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
         }
 
         get("/minside-widget") {
+            val now = LocalDate.now()
+            val visningFom = now.minusDays(WIDGET_DAYS_BACK)
+            val tom = now.plusDays(WIDGET_DAYS_FORWARD)
+
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
-                fom = LocalDate.now().minusDays(31),
-                tom = LocalDate.now().plusDays(7)
+                fom = visningFom.minusDays(WIDGET_FROM_DATE_OFFSET_DAYS),
+                tom = tom
             )
 
-            call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
+            call.respond(
+                HttpStatusCode.OK,
+                SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling, visningFom, tom)
+            )
         }
 
         get("/{ytelseId}") {
@@ -133,6 +140,11 @@ val ApplicationCall.fromDateParam: LocalDate
     )
 
 private const val FROM_DATE_OFFSET_DAYS = 20L
+
+private const val WIDGET_DAYS_BACK = 21L
+private const val WIDGET_DAYS_FORWARD = 7L
+private const val WIDGET_FROM_DATE_OFFSET_DAYS = 30L
+
 private val EARLIEST_POSSIBLE_FROM_DATE get() = LocalDate.now().minusYears(3).withDayOfYear(1)
 private fun getEarlierFromDateWithinMaxBound(fromDate: LocalDate): LocalDate {
     val adjustedDate = fromDate.minusDays(FROM_DATE_OFFSET_DAYS)

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -39,6 +39,16 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
             call.respond(HttpStatusCode.OK, SisteOgNesteUtbetaling.fromSokosResponse(sisteUtbetaling))
         }
 
+        get("/minside-widget") {
+            val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
+                user = call.user,
+                fom = LocalDate.now().minusMonths(3),
+                tom = LocalDate.now().plusMonths(3)
+            )
+
+            call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
+        }
+
         get("/{ytelseId}") {
 
             val ytelseId = call.parameters["ytelseId"] ?: throw IllegalYtelseIdException("Ytelseid kan ikke være null")

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -42,7 +42,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
         get("/minside-widget") {
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
-                fom = LocalDate.now().minusDays(21),
+                fom = LocalDate.now().minusDays(90),
                 tom = LocalDate.now().plusDays(7)
             )
 

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -42,7 +42,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
         get("/minside-widget") {
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
-                fom = LocalDate.now().minusDays(90),
+                fom = LocalDate.now().minusDays(21),
                 tom = LocalDate.now().plusDays(7)
             )
 

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -141,7 +141,7 @@ val ApplicationCall.fromDateParam: LocalDate
 
 private const val FROM_DATE_OFFSET_DAYS = 20L
 
-private const val WIDGET_DAYS_BACK = 21L
+private const val WIDGET_DAYS_BACK = 31L
 private const val WIDGET_DAYS_FORWARD = 7L
 private const val WIDGET_FROM_DATE_OFFSET_DAYS = 30L
 

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -42,8 +42,8 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
         get("/minside-widget") {
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
-                fom = LocalDate.now().minusMonths(3),
-                tom = LocalDate.now().plusMonths(3)
+                fom = LocalDate.now().minusDays(21),
+                tom = LocalDate.now().minusDays(21)
             )
 
             call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
@@ -94,6 +94,16 @@ fun Route.utbetalingRoutesTokenX(sokosUtbetalingConsumer: SokosUtbetalingConsume
             )
 
             call.respond(HttpStatusCode.OK, SisteOgNesteUtbetaling.fromSokosResponse(sisteUtbetaling))
+        }
+
+        get("/minside-widget") {
+            val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
+                user = call.user,
+                fom = LocalDate.now().minusDays(21),
+                tom = LocalDate.now().minusDays(21)
+            )
+
+            call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
         }
 
         get("/{ytelseId}") {

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -44,7 +44,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
             val visningFom = now.minusDays(WIDGET_DAYS_BACK)
             val tom = now.plusDays(WIDGET_DAYS_FORWARD)
 
-            val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
+            val sisteUtbetalinger = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
                 fom = visningFom.minusDays(WIDGET_FROM_DATE_OFFSET_DAYS),
                 tom = tom
@@ -52,7 +52,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
 
             call.respond(
                 HttpStatusCode.OK,
-                SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling, visningFom, tom)
+                SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetalinger, visningFom, tom)
             )
         }
 

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -42,7 +42,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
         get("/minside-widget") {
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
-                fom = LocalDate.now().minusDays(21),
+                fom = LocalDate.now().minusDays(31),
                 tom = LocalDate.now().plusDays(7)
             )
 

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/utbetalingRoutesV2.kt
@@ -43,7 +43,7 @@ fun Route.utbetalingRoutes(sokosUtbetalingConsumer: SokosUtbetalingConsumer) {
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
                 fom = LocalDate.now().minusDays(21),
-                tom = LocalDate.now().minusDays(21)
+                tom = LocalDate.now().plusDays(7)
             )
 
             call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))
@@ -100,7 +100,7 @@ fun Route.utbetalingRoutesTokenX(sokosUtbetalingConsumer: SokosUtbetalingConsume
             val sisteUtbetaling = sokosUtbetalingConsumer.fetchUtbetalingsInfo(
                 user = call.user,
                 fom = LocalDate.now().minusDays(21),
-                tom = LocalDate.now().minusDays(21)
+                tom = LocalDate.now().plusDays(7)
             )
 
             call.respond(HttpStatusCode.OK, SisteOgKommendeUtbetalinger.fromSokosResponse(sisteUtbetaling))

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/ytelse/domain/external/UtbetalingEkstern.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/ytelse/domain/external/UtbetalingEkstern.kt
@@ -75,6 +75,20 @@ data class UtbetalingEkstern(
                 .filter { !it.erUtbetalt(now) }
                 .minByOrNull { it.ytelsesdato()!! }
 
+
+        fun List<UtbetalingEkstern>.listeMedSisteUtbetalinger(now: LocalDate, antall: Int): List<UtbetalingEkstern> =
+            filter { it.harYtelsesdato() }
+                .filter { it.erUtbetalt(now) }
+                .sortedByDescending { it.ytelsesdato() }
+                .take(antall)
+
+
+        fun List<UtbetalingEkstern>.listeMedKommendeUtbetalinger(now: LocalDate, antall: Int): List<UtbetalingEkstern> =
+            filter { it.harYtelsesdato() }
+                .filter { !it.erUtbetalt(now) }
+                .sortedBy { it.ytelsesdato()!! }
+                .take(antall)
+
     }
 
 }

--- a/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/ytelse/domain/external/UtbetalingEkstern.kt
+++ b/src/main/kotlin/no/nav/tms/utbetalingsoversikt/api/ytelse/domain/external/UtbetalingEkstern.kt
@@ -83,11 +83,10 @@ data class UtbetalingEkstern(
                 .take(antall)
 
 
-        fun List<UtbetalingEkstern>.listeMedKommendeUtbetalinger(now: LocalDate, antall: Int): List<UtbetalingEkstern> =
+        fun List<UtbetalingEkstern>.listeMedKommendeUtbetalinger(now: LocalDate): List<UtbetalingEkstern> =
             filter { it.harYtelsesdato() }
                 .filter { !it.erUtbetalt(now) }
                 .sortedBy { it.ytelsesdato()!! }
-                .take(antall)
 
     }
 

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/TestData.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/TestData.kt
@@ -74,7 +74,7 @@ internal fun sokoTestResponse(
 
 
 @Language("JSON")
-fun nesteYtelseJson(plusDays: Long = 5) = """
+fun treKommendeUtbetalingerJson(plusDays: Long = 5) = """
       {
         "posteringsdato": "${LocalDate.now().minusDays(plusDays)}",
         "utbetaltTil": {
@@ -212,7 +212,91 @@ fun nesteYtelseJson(plusDays: Long = 5) = """
 """.trimIndent()
 
 @Language("JSON")
-fun tidligereYtelseJson(
+fun enUtbetalingJson(
+    dagerFraNaa: Long = 5,
+    erTidligere: Boolean = false,
+    ytelse: String = "Foreldrepenger",
+    utbetaltBeløp: Double = 1000.0,
+    trekkBeløp: Double = 200.0,
+    kontonummer: String = "1234567890",
+    satsAntall: Int = 1,
+) : String {
+    val ytelsesdato = if (erTidligere) {
+        LocalDate.now().minusDays(dagerFraNaa)
+    } else {
+        LocalDate.now().plusDays(dagerFraNaa)
+    }
+
+    val utbetalingsdato = if (erTidligere) {
+        "\"$ytelsesdato\""
+    } else {
+        "null"
+    }
+
+    return """
+      {
+        "posteringsdato": "${LocalDate.now().minusDays(dagerFraNaa)}",
+        "utbetaltTil": {
+          "aktoertype": "PERSON",
+          "ident": "123345567",
+          "navn": "string"
+        },
+        "utbetalingNettobeloep": $utbetaltBeløp,
+        "utbetalingsmelding": "string",
+        "utbetalingsdato": $utbetalingsdato,
+        "forfallsdato": "$ytelsesdato",
+        "utbetaltTilKonto": {
+          "kontonummer": "$kontonummer",
+          "kontotype": "Norsk bank"
+        },
+        "utbetalingsmetode": "Til konto",
+        "utbetalingsstatus": "something",
+        "ytelseListe": [
+          {
+            "ytelsestype": "$ytelse",
+            "ytelsesperiode": {
+              "fom": "$ytelsesdato",
+              "tom": "$ytelsesdato"
+            },
+            "ytelseskomponentListe": [
+              {
+                "ytelseskomponenttype": "string",
+                "satsbeloep": ${utbetaltBeløp+trekkBeløp},
+                "satstype": "string",
+                "satsantall": $satsAntall,
+                "ytelseskomponentbeloep": 42
+              }
+            ],
+            "ytelseskomponentersum": 111.22,
+            "trekkListe": [
+              {
+                "trekktype": "string",
+                "trekkbeloep": 100,
+                "kreditor": "string"
+              }
+            ],
+            "trekksum": $trekkBeløp,
+            "skattListe": [
+              {
+                "skattebeloep": 99.9
+              }
+            ],
+            "skattsum": 1000.5,
+            "ytelseNettobeloep": $utbetaltBeløp,
+            "bilagsnummer": "84172491",
+            "rettighetshaver": {
+              "aktoertype": "PERSON",
+              "ident": "1234567890g",
+              "navn": "Navn Navnesen"
+            }
+          }
+        ]
+      }
+""".trimIndent()
+}
+
+@Language("JSON")
+fun treTidligereUtbetalinger(
     minusDays: Long,
     nettoUtbetalt: Double,
     økonomiskSosialhjelp: NettoOgTrekk,
@@ -369,7 +453,7 @@ internal fun Int.tidligereYtelser(
     val trekkPrThing = (expectedTrekk / this) / 3
     for (i in 1..this) {
         ytelse.add(
-            tidligereYtelseJson(
+            treTidligereUtbetalinger(
                 minusDays = this.toLong() * 8,
                 nettoUtbetalt = expectedUtbetalt,
                 økonomiskSosialhjelp = NettoOgTrekk(expectedØkonomiskSosialhjelp - trekkPrThing, trekkPrThing),

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -63,9 +63,9 @@ class UtbetalingRoutesTest {
         withExternalServiceResponse(
             """
           ${tidligereUtbetalingerJson.substring(0, tidligereUtbetalingerJson.lastIndexOf("]"))},
-          ${nesteYtelseJson(15)},   
-          ${nesteYtelseJson(1)},     
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(15)},   
+          ${treKommendeUtbetalingerJson(1)},     
+          ${treKommendeUtbetalingerJson(20)}    
            ]
             
         """.trimIndent()
@@ -102,9 +102,9 @@ class UtbetalingRoutesTest {
         withExternalServiceResponse(
             body = """
           ${tidligereUtbetalingerJson.substring(0, tidligereUtbetalingerJson.lastIndexOf("]"))},
-          ${nesteYtelseJson(1)},    
-          ${nesteYtelseJson(15)},    
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(1)},    
+          ${treKommendeUtbetalingerJson(15)},    
+          ${treKommendeUtbetalingerJson(20)}    
            ]
             
         """.trimIndent()
@@ -159,9 +159,9 @@ class UtbetalingRoutesTest {
         withExternalServiceResponse(
             body = """
           ${tidligereUtbetalingerJson.substring(0, tidligereUtbetalingerJson.lastIndexOf("]"))},
-          ${nesteYtelseJson(1)},    
-          ${nesteYtelseJson(15)},    
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(1)},    
+          ${treKommendeUtbetalingerJson(15)},    
+          ${treKommendeUtbetalingerJson(20)}    
            ]
         """.trimIndent()
         ) {
@@ -246,9 +246,9 @@ class UtbetalingRoutesTest {
         )
         withExternalServiceResponse(
             body = """[
-          ${nesteYtelseJson(1)},    
-          ${nesteYtelseJson(15)},    
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(1)},    
+          ${treKommendeUtbetalingerJson(15)},    
+          ${treKommendeUtbetalingerJson(20)}    
            ]
         """.trimIndent()
         ) {
@@ -478,7 +478,7 @@ class UtbetalingRoutesTest {
         withExternalServiceResponse(
             """
           ${tidligereUtbetalingerJson.substring(0, tidligereUtbetalingerJson.lastIndexOf("]"))},
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(20)}    
            ]
             
         """.trimIndent()
@@ -506,7 +506,7 @@ class UtbetalingRoutesTest {
         withExternalServiceResponse(
             body = """
           ${tidligereUtbetalingerJson.substring(0, tidligereUtbetalingerJson.lastIndexOf("]"))},
-          ${nesteYtelseJson(20)}    
+          ${treKommendeUtbetalingerJson(20)}    
            ]
         """.trimIndent()
         ) {
@@ -555,10 +555,10 @@ class UtbetalingRoutesTest {
 
         withExternalServiceResponse(
             body = """[
-                ${tidligereYtelseJson(1, 2000.0, 1100.0 to 1000.0, 1200.0 to 1000.0, 1300.0 to 1000.0)},
-                ${tidligereYtelseJson(3, 8700.0, 2311.13 to 1000.0, 2600.87 to 1000.0, 3788.0 to 1000.0)},
-                ${nesteYtelseJson(3)},
-                ${nesteYtelseJson(1)}
+                ${treTidligereUtbetalinger(1, 2000.0, 1100.0 to 1000.0, 1200.0 to 1000.0, 1300.0 to 1000.0)},
+                ${treTidligereUtbetalinger(3, 8700.0, 2311.13 to 1000.0, 2600.87 to 1000.0, 3788.0 to 1000.0)},
+                ${treKommendeUtbetalingerJson(3)},
+                ${treKommendeUtbetalingerJson(1)}
             ]""".trimIndent()
         ) {
             val fomtom = objectMapper.readTree(call.receiveText())
@@ -593,6 +593,94 @@ class UtbetalingRoutesTest {
         }
     }
 
+    @Test
+    fun `returnerer kun én tidligere utbetaling for minside-widget for tokenx`() = testApplication {
+        testApi(
+            SokosUtbetalingConsumer(client = sokosHttpClient, baseUrl = createUrl(testHost), tokenExchanger = tokendingsMockk, sokosUtbetaldataClientId = "test:client:id")
+        )
+        val enkelUtbetaling = enUtbetalingJson(
+            dagerFraNaa = 1,
+            erTidligere = true,
+            ytelse = "Foreldrepenger",
+            utbetaltBeløp = 1200.0,
+            trekkBeløp = 1000.0
+        )
+
+        withExternalServiceResponse(
+            body = """[
+                $enkelUtbetaling
+            ]""".trimIndent()
+        ) { hasMinsideWidgetRequestWindow() }
+
+        client.get("/utbetalinger/ssr/minside-widget") {
+            mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
+        }.assert {
+            status shouldBe HttpStatusCode.OK
+            val response = objectMapper.readTree(bodyAsText())
+
+            response["sisteUtbetalinger"].toList().size shouldBe 1
+            response["kommendeUtbetalinger"].toList().size shouldBe 0
+
+            response["sisteUtbetalinger"][0]["dato"].asText() shouldBe LocalDate.now().minusDays(1).toString()
+            response["sisteUtbetalinger"][0]["ytelse"].asText() shouldBe "Foreldrepenger"
+            response["sisteUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 1200.0
+        }
+    }
+
+    @Test
+    fun `returnerer kun én kommende utbetaling for minside-widget for tokenx`() = testApplication {
+        testApi(
+            SokosUtbetalingConsumer(client = sokosHttpClient, baseUrl = createUrl(testHost), tokenExchanger = tokendingsMockk, sokosUtbetaldataClientId = "test:client:id")
+        )
+        val enkelUtbetaling = enUtbetalingJson(
+            dagerFraNaa = 5,
+            erTidligere = false,
+            ytelse = "Dagpenger",
+            utbetaltBeløp = 3788.0,
+            trekkBeløp = 1000.0,
+            kontonummer = "888777666555444"
+        )
+
+        withExternalServiceResponse(
+            body = """[
+                $enkelUtbetaling
+            ]""".trimIndent()
+        ) { hasMinsideWidgetRequestWindow() }
+
+        client.get("/utbetalinger/ssr/minside-widget") {
+            mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
+        }.assert {
+            status shouldBe HttpStatusCode.OK
+            val response = objectMapper.readTree(bodyAsText())
+
+            response["sisteUtbetalinger"].toList().size shouldBe 0
+            response["kommendeUtbetalinger"].toList().size shouldBe 1
+
+            response["kommendeUtbetalinger"][0]["dato"].asText() shouldBe LocalDate.now().plusDays(5).toString()
+            response["kommendeUtbetalinger"][0]["ytelse"].asText() shouldBe "Dagpenger"
+            response["kommendeUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 3788.0
+        }
+    }
+
+    @Test
+    fun `returnerer tomme lister for minside-widget når det ikke finnes utbetalinger`() = testApplication {
+        testApi(
+            SokosUtbetalingConsumer(client = sokosHttpClient, baseUrl = createUrl(testHost), tokenExchanger = tokendingsMockk, sokosUtbetaldataClientId = "test:client:id")
+        )
+
+        withExternalServiceResponse("[]") { hasMinsideWidgetRequestWindow() }
+
+        client.get("/utbetalinger/ssr/minside-widget") {
+            mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
+        }.assert {
+            status shouldBe HttpStatusCode.OK
+            val response = objectMapper.readTree(bodyAsText())
+
+            response["sisteUtbetalinger"].toList().size shouldBe 0
+            response["kommendeUtbetalinger"].toList().size shouldBe 0
+        }
+    }
+
     private fun ApplicationTestBuilder.withExternalServiceResponse(
         body: String,
         replyIf: suspend RoutingContext.() -> Boolean = { true }
@@ -616,6 +704,15 @@ class UtbetalingRoutesTest {
 
             }
         }
+    }
+
+    private suspend fun RoutingContext.hasMinsideWidgetRequestWindow(): Boolean {
+        val fomtom = objectMapper.readTree(call.receiveText())
+        val expectedFom = LocalDate.now().minusDays(21)
+        val expectedTom = LocalDate.now().plusDays(8)
+        val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
+        val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())
+        return actualFom == expectedFom && actualTom == expectedTom
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -562,7 +562,7 @@ class UtbetalingRoutesTest {
             ]""".trimIndent()
         ) {
             val fomtom = objectMapper.readTree(call.receiveText())
-            val expectedFom = LocalDate.now().minusDays(21)
+            val expectedFom = LocalDate.now().minusDays(31)
             val expectedTom = LocalDate.now().plusDays(8)
             val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
             val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())
@@ -708,7 +708,7 @@ class UtbetalingRoutesTest {
 
     private suspend fun RoutingContext.hasMinsideWidgetRequestWindow(): Boolean {
         val fomtom = objectMapper.readTree(call.receiveText())
-        val expectedFom = LocalDate.now().minusDays(21)
+        val expectedFom = LocalDate.now().minusDays(31)
         val expectedTom = LocalDate.now().plusDays(8)
         val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
         val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -547,6 +547,52 @@ class UtbetalingRoutesTest {
         }
     }
 
+    @Test
+    fun `returnerer siste og kommende utbetalinger for minside-widget for tokenx`() = testApplication {
+        testApi(
+            SokosUtbetalingConsumer(client = sokosHttpClient, baseUrl = createUrl(testHost), tokenExchanger = tokendingsMockk, sokosUtbetaldataClientId = "test:client:id")
+        )
+
+        withExternalServiceResponse(
+            body = """[
+                ${tidligereYtelseJson(1, 2000.0, 1100.0 to 1000.0, 1200.0 to 1000.0, 1300.0 to 1000.0)},
+                ${tidligereYtelseJson(3, 8700.0, 2311.13 to 1000.0, 2600.87 to 1000.0, 3788.0 to 1000.0)},
+                ${nesteYtelseJson(3)},
+                ${nesteYtelseJson(1)}
+            ]""".trimIndent()
+        ) {
+            val fomtom = objectMapper.readTree(call.receiveText())
+            val expectedFom = LocalDate.now().minusDays(21)
+            val expectedTom = LocalDate.now().plusDays(8)
+            val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
+            val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())
+            actualFom == expectedFom && actualTom == expectedTom
+        }
+
+        client.get("/utbetalinger/ssr/minside-widget") {
+            mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
+        }.assert {
+            status shouldBe HttpStatusCode.OK
+            val response = objectMapper.readTree(bodyAsText())
+            response["sisteUtbetalinger"].toList().size shouldBe 2
+            response["kommendeUtbetalinger"].toList().size shouldBe 2
+
+            response["sisteUtbetalinger"][0]["dato"].asText() shouldBe LocalDate.now().minusDays(1).toString()
+            response["sisteUtbetalinger"][0]["ytelse"].asText() shouldBe "Foreldrepenger"
+            response["sisteUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 1200.0
+            response["sisteUtbetalinger"][1]["ytelse"].asText() shouldBe "Økonomisk Sosialhjelp"
+            response["sisteUtbetalinger"][1]["utbetaling"].asText().toDouble() shouldBe 1100.0
+
+
+            response["kommendeUtbetalinger"][0]["dato"].asText() shouldBe LocalDate.now().plusDays(1).toString()
+            response["kommendeUtbetalinger"][0]["ytelse"].asText() shouldBe "Dagpenger"
+            response["kommendeUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 3788.0
+            response["kommendeUtbetalinger"][1]["ytelse"].asText() shouldBe "Foreldrepenger"
+            response["kommendeUtbetalinger"][1]["utbetaling"].asText().toDouble() shouldBe 2600.87
+
+        }
+    }
+
     private fun ApplicationTestBuilder.withExternalServiceResponse(
         body: String,
         replyIf: suspend RoutingContext.() -> Boolean = { true }

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -546,7 +546,7 @@ class UtbetalingRoutesTest {
             status shouldBe HttpStatusCode.OK
         }
     }
-/*
+
     @Test
     fun `returnerer siste og kommende utbetalinger for minside-widget for tokenx`() = testApplication {
         testApi(
@@ -660,7 +660,7 @@ class UtbetalingRoutesTest {
             response["kommendeUtbetalinger"][0]["ytelse"].asText() shouldBe "Dagpenger"
             response["kommendeUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 3788.0
         }
-    }*/
+    }
 
     @Test
     fun `returnerer tomme lister for minside-widget når det ikke finnes utbetalinger`() = testApplication {

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -569,7 +569,7 @@ class UtbetalingRoutesTest {
             actualFom == expectedFom && actualTom == expectedTom
         }
 
-        client.get("/utbetalinger/ssr/minside-widget") {
+        client.get("/utbetalinger/minside-widget") {
             mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
         }.assert {
             status shouldBe HttpStatusCode.OK
@@ -612,7 +612,7 @@ class UtbetalingRoutesTest {
             ]""".trimIndent()
         ) { hasMinsideWidgetRequestWindow() }
 
-        client.get("/utbetalinger/ssr/minside-widget") {
+        client.get("/utbetalinger/minside-widget") {
             mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
         }.assert {
             status shouldBe HttpStatusCode.OK
@@ -647,7 +647,7 @@ class UtbetalingRoutesTest {
             ]""".trimIndent()
         ) { hasMinsideWidgetRequestWindow() }
 
-        client.get("/utbetalinger/ssr/minside-widget") {
+        client.get("/utbetalinger/minside-widget") {
             mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
         }.assert {
             status shouldBe HttpStatusCode.OK
@@ -670,7 +670,7 @@ class UtbetalingRoutesTest {
 
         withExternalServiceResponse("[]") { hasMinsideWidgetRequestWindow() }
 
-        client.get("/utbetalinger/ssr/minside-widget") {
+        client.get("/utbetalinger/minside-widget") {
             mockAuthorizedHeader(ident = "12345", issuer = Issuer.Tokenx, levelOfAssurance = LevelOfAssurance.Substantial)
         }.assert {
             status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -546,7 +546,7 @@ class UtbetalingRoutesTest {
             status shouldBe HttpStatusCode.OK
         }
     }
-
+/*
     @Test
     fun `returnerer siste og kommende utbetalinger for minside-widget for tokenx`() = testApplication {
         testApi(
@@ -618,7 +618,7 @@ class UtbetalingRoutesTest {
             status shouldBe HttpStatusCode.OK
             val response = objectMapper.readTree(bodyAsText())
 
-            response["sisteUtbetalinger"].toList().size shouldBe 1
+           response["sisteUtbetalinger"].toList().size shouldBe 1
             response["kommendeUtbetalinger"].toList().size shouldBe 0
 
             response["sisteUtbetalinger"][0]["dato"].asText() shouldBe LocalDate.now().minusDays(1).toString()
@@ -660,7 +660,7 @@ class UtbetalingRoutesTest {
             response["kommendeUtbetalinger"][0]["ytelse"].asText() shouldBe "Dagpenger"
             response["kommendeUtbetalinger"][0]["utbetaling"].asText().toDouble() shouldBe 3788.0
         }
-    }
+    }*/
 
     @Test
     fun `returnerer tomme lister for minside-widget når det ikke finnes utbetalinger`() = testApplication {

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -562,7 +562,7 @@ class UtbetalingRoutesTest {
             ]""".trimIndent()
         ) {
             val fomtom = objectMapper.readTree(call.receiveText())
-            val expectedFom = LocalDate.now().minusDays(31)
+            val expectedFom = LocalDate.now().minusDays(51)
             val expectedTom = LocalDate.now().plusDays(8)
             val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
             val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())
@@ -708,7 +708,7 @@ class UtbetalingRoutesTest {
 
     private suspend fun RoutingContext.hasMinsideWidgetRequestWindow(): Boolean {
         val fomtom = objectMapper.readTree(call.receiveText())
-        val expectedFom = LocalDate.now().minusDays(31)
+        val expectedFom = LocalDate.now().minusDays(51)
         val expectedTom = LocalDate.now().plusDays(8)
         val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
         val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())

--- a/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/utbetalingsoversikt/api/utbetaling/UtbetalingRoutesTest.kt
@@ -562,7 +562,7 @@ class UtbetalingRoutesTest {
             ]""".trimIndent()
         ) {
             val fomtom = objectMapper.readTree(call.receiveText())
-            val expectedFom = LocalDate.now().minusDays(51)
+            val expectedFom = LocalDate.now().minusDays(61)
             val expectedTom = LocalDate.now().plusDays(8)
             val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
             val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())
@@ -708,7 +708,7 @@ class UtbetalingRoutesTest {
 
     private suspend fun RoutingContext.hasMinsideWidgetRequestWindow(): Boolean {
         val fomtom = objectMapper.readTree(call.receiveText())
-        val expectedFom = LocalDate.now().minusDays(51)
+        val expectedFom = LocalDate.now().minusDays(61)
         val expectedTom = LocalDate.now().plusDays(8)
         val actualFom = LocalDate.parse(fomtom["periode"]["fom"].asText())
         val actualTom = LocalDate.parse(fomtom["periode"]["tom"].asText())


### PR DESCRIPTION
Ny route, /minside-widget, for å vise en liste med tidligere og kommende utbetalinger på Min side. Den skal samsvare med listene fra /alle, men med maks fire utbetalinger og et tidsintervall på 31 dager tilbake i tid og 7 dager frem i tid.